### PR TITLE
composer: fix autoload-dev for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "league\\CommonMark\\Ext\\SmartPunct\\Test\\": "tests"
+            "League\\CommonMark\\Ext\\SmartPunct\\Tests\\": "tests"
         }
     },
     "scripts": {


### PR DESCRIPTION
looks like this problem has spewed over multiple repositories.

refs:
- https://github.com/thephpleague/commonmark-ext-inlines-only/pull/1