### PR TITLE
changelog: reformat and fix changelog links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
-All notable changes will be documented in this file.
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][unreleased]
 
-## 0.1.0 - 2019-03-11
+[unreleased]: https://github.com/thephpleague/commonmark-ext-smartpunct/compare/v0.1.0...HEAD
 
-Forked this extension out of the old `league/commonmark-extras` library.
+## [0.1.0] - 2019-03-11
 
-[unreleased]: https://github.com/thephpleague/commonmark-ext-smartpunct/compare/0.1.0...HEAD
+Split this extension out of the old `league/commonmark-extras` library.
+
+[0.1.0]: https://github.com/thephpleague/commonmark-ext-smartpunct/commits/v0.1.0


### PR DESCRIPTION
1. technically you did not fork, but split.
2. added link to keepachangelog.com doc
3. fixed links, `v` prefix is used for tagging in this project 